### PR TITLE
Fix rapidjson "call to constructor is ambiguous" errors.

### DIFF
--- a/src/json_sink.cpp
+++ b/src/json_sink.cpp
@@ -76,7 +76,7 @@ struct json_sink_t : data_sink_t
         val.AddMember("file", ai.file, doc.GetAllocator());
         if (ai.full_name)
             val.AddMember("full_name",  boost::replace_all_copy(*ai.full_name, "\\\\", "\\"), doc.GetAllocator());
-        val.AddMember("line", ai.line, doc.GetAllocator());
+        val.AddMember("line", static_cast<int>(ai.line), doc.GetAllocator());
         if (ai.function)
             val.AddMember("function", *ai.function, doc.GetAllocator());
         if (ai.offset)
@@ -175,7 +175,7 @@ struct json_sink_t : data_sink_t
                     auto & i = *c.info;
                     if (i.function)
                         val.AddMember("fn", *i.function, doc.GetAllocator());
-                    val.AddMember("line", i.line, doc.GetAllocator());
+                    val.AddMember("line", static_cast<int>(i.line), doc.GetAllocator());
                     val.AddMember("file", boost::replace_all_copy(i.file, "\\\\", "\\"), doc.GetAllocator());
                     if (i.full_name)
                         val.AddMember("full_name", boost::replace_all_copy(*i.full_name, "\\\\", "\\"), doc.GetAllocator());
@@ -262,7 +262,7 @@ struct json_sink_t : data_sink_t
         val.AddMember("type", "incomplete", doc.GetAllocator());
 
         val.AddMember("position", position, doc.GetAllocator());
-        val.AddMember("size", cc.content().size(), doc.GetAllocator());
+        val.AddMember("size", static_cast<uint64_t>(cc.content().size()), doc.GetAllocator());
 
         rj::Value ct;
         ct.SetObject();


### PR DESCRIPTION
`rapidjson::GenericValue` doesn't have constructors for the types you pass in, therefore this creates compile errors such as:
```
In file included from calltrace/src/json_sink.cpp:23:
libs/rapidjson/include/rapidjson/document.h:1322:22: error: call to constructor of 'rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >' is ambiguous
        GenericValue v(value);
                     ^ ~~~~~
libs/rapidjson/include/rapidjson/document.h:1393:16: note: in instantiation of function template specialization 'rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::AddMember<unsigned long>' requested here
        return AddMember(n, value, allocator);
               ^
calltrace/src/json_sink.cpp:79:13: note: in instantiation of function template specialization 'rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::AddMember<unsigned long>' requested here
        val.AddMember("line", ai.line, doc.GetAllocator());
libs/rapidjson/include/rapidjson/document.h:693:14: note: candidate constructor
    explicit GenericValue(int i) RAPIDJSON_NOEXCEPT : data_() {
             ^
libs/rapidjson/include/rapidjson/document.h:699:14: note: candidate constructor
    explicit GenericValue(unsigned u) RAPIDJSON_NOEXCEPT : data_() {
             ^
libs/rapidjson/include/rapidjson/document.h:705:14: note: candidate constructor
    explicit GenericValue(int64_t i64) RAPIDJSON_NOEXCEPT : data_() {
             ^
libs/rapidjson/include/rapidjson/document.h:720:14: note: candidate constructor
    explicit GenericValue(uint64_t u64) RAPIDJSON_NOEXCEPT : data_() {
             ^
libs/rapidjson/include/rapidjson/document.h:732:14: note: candidate constructor
    explicit GenericValue(double d) RAPIDJSON_NOEXCEPT : data_() { data_.n.d = d; data_.f.flags = kNumberDoubleFlag; }
             ^
libs/rapidjson/include/rapidjson/document.h:735:14: note: candidate constructor
    explicit GenericValue(float f) RAPIDJSON_NOEXCEPT : data_() { data_.n.d = static_cast<double>(f); data_.f.flags = kNumberDoubleFlag; }
             ^
```


Please check if these casts are appropriate.

cc @timonwalther @klemens-morgenstern 